### PR TITLE
Feat/lookahead casesplits

### DIFF
--- a/src/c2_casesplits.c
+++ b/src/c2_casesplits.c
@@ -15,24 +15,24 @@
 
 void c2_backtrack_case_split(C2* c2) {
     V2("Backtracking from case split.\n");
-    
+
     V1("Finished case:");
     for (unsigned i = 0; i < int_vector_count(c2->case_split_stack); i++) {
         V1(" %d", int_vector_get(c2->case_split_stack, i));
     }
     V1("\n");
-    
+
     c2_backtrack_to_decision_lvl(c2, c2->restart_base_decision_lvl);
     V3("Now popping the case split.\n");
     stack_pop(c2->stack, c2);
     c2_pop(c2);
-    
+
     c2->skolem->decision_lvl -=1;
     c2->restart_base_decision_lvl -= 1;
-    
+
     assert(c2->skolem->decision_lvl == 0); // TODO: If we do case splits after dlvl 0, we should also add a real clause
     assert(c2->restart_base_decision_lvl == 0);
-    
+
     int_vector* solved_cube = int_vector_init();
     vector_add(c2->skolem->cegar->solved_cubes, solved_cube);
     for (unsigned i = 0; i < int_vector_count(c2->case_split_stack); i++) {
@@ -43,7 +43,7 @@ void c2_backtrack_case_split(C2* c2) {
         int_vector_add(solved_cube, -l);
     }
     satsolver_clause_finished(c2->skolem->skolem);
-    
+
     // check learnt clauses for unique consequences ... the last backtracking may have removed the unique consequences
     for (unsigned i = vector_count(c2->qcnf->clauses); i > 0; i--) {
         Clause* c = vector_get(c2->qcnf->clauses, i-1);
@@ -56,16 +56,16 @@ void c2_backtrack_case_split(C2* c2) {
             }
         }
     }
-    
+
     int_vector_reset(c2->case_split_stack);
-    
+
     // Test if we exhausted all cases
     assert(int_vector_count(c2->case_split_stack) == 0);
     if (satsolver_sat(c2->skolem->skolem) == SATSOLVER_UNSATISFIABLE) {
         V1("Universal assignments depleted: SAT\n");
         c2->result = CADET_RESULT_SAT;
     }
-    
+
 }
 
 void c2_case_split_backtracking_heuristics(C2* c2) {
@@ -76,24 +76,24 @@ void c2_case_split_backtracking_heuristics(C2* c2) {
 unsigned c2_assume_constant(C2* c2, Lit lit) {
     assert(!skolem_can_propagate(c2->skolem));
     statistics_start_timer(c2->statistics.failed_literals_stats);
-    
+
     size_t case_split_decision_metric = c2->skolem->statistics.propagations;
-    
+
     skolem_push(c2->skolem);
     skolem_assume_constant_value(c2->skolem, lit);
     skolem_propagate(c2->skolem);
-    
+
     if (skolem_is_conflicted(c2->skolem)) {
         V1("Skolem conflict with assumed constant %d: %d\n", lit, c2->skolem->conflict_var_id);
         c2->statistics.failed_literals_conflicts++;
         case_split_decision_metric += 1024; //Magic number to ensure the variable is chosen
     }
-    
+
     V2("Number of propagations when assigning %d: %zu\n", lit, c2->skolem->statistics.propagations - case_split_decision_metric);
-    
+
     skolem_pop(c2->skolem);
     statistics_stop_and_record_timer(c2->statistics.failed_literals_stats);
-    
+
     return case_split_decision_metric;
 }
 
@@ -115,9 +115,9 @@ Lit c2_case_split_pick_literal(C2* c2) {
 }
 
 bool c2_case_split(C2* c2) {
-    
+
     bool progress = false; // indicates whether this function call changed anything.
-    
+
 //    Lit most_notorious_literal = c2_pick_most_notorious_literal(c2);
     Lit most_notorious_literal = c2_case_split_pick_literal(c2);
     if (most_notorious_literal != 0) {
@@ -125,17 +125,17 @@ bool c2_case_split(C2* c2) {
         if (debug_verbosity >= VERBOSITY_LOW) {
             V1("Found notorious literal");
             options_print_literal_name(c2->options, c2_literal_color(c2, NULL, most_notorious_literal), most_notorious_literal);
-            V1(" with notoriousity %.2f; greater than threshold %.2f.\n", notoriousity, threshold);
+            V1(" \n");
         }
-        
+
         satsolver_assume(c2->skolem->skolem, skolem_get_satsolver_lit(c2->skolem, most_notorious_literal));
-        
+
         sat_res res = satsolver_sat(c2->skolem->skolem);
         if (res != SATSOLVER_SATISFIABLE) {
             V1("This case admits no assignments to the universals that are consistent with dlvl 0, switching polarity and assuming %d instead.\n", - most_notorious_literal);
-            
+
             most_notorious_literal = - most_notorious_literal;
-            
+
             satsolver_assume(c2->skolem->skolem, skolem_get_satsolver_lit(c2->skolem, most_notorious_literal));
             sat_res res = satsolver_sat(c2->skolem->skolem);
             assert(c2->skolem->decision_lvl == c2->restart_base_decision_lvl);
@@ -154,7 +154,7 @@ bool c2_case_split(C2* c2) {
                 most_notorious_literal = 0; // suppresses that case split happens
             }
         }
-        
+
         if (most_notorious_literal != 0) {
             progress = true;
             if (int_vector_count(c2->case_split_stack) == 0) {
@@ -164,14 +164,14 @@ bool c2_case_split(C2* c2) {
                 c2->skolem->decision_lvl +=1;
                 c2->restart_base_decision_lvl += 1;
             }
-            
+
             int_vector_add(c2->case_split_stack, most_notorious_literal);
-            
+
             assert(skolem_is_deterministic(c2->skolem, lit_to_var(most_notorious_literal)));
             skolem_assume_constant_value(c2->skolem, most_notorious_literal);
-            
+
             skolem_propagate(c2->skolem);
-            
+
             if (skolem_is_conflicted(c2->skolem)) { // actual conflict
                 assert(c2->skolem->decision_lvl == c2->restart_base_decision_lvl); // otherwise we need to go into conflict analysis
                 V1("Case split lead to immediate conflict.\n");
@@ -232,13 +232,13 @@ int c2_pick_most_notorious_literal(C2* c2) {
         //        if (skolem_compare_dependencies(c2->skolem, skolem_get_dependencies(c2->skolem, i), c2->skolem->empty_dependencies) != DEPS_EQUAL) {
         //            continue;
         //        }
-        
+
         float notoriousity_pos = c2_notoriousity(c2,   (int) i);
         if (notoriousity_pos > notoriousity) {
             notoriousity = notoriousity_pos;
             notorious_lit = (Lit) i;
         }
-        
+
         float notoriousity_neg = c2_notoriousity(c2, - (int) i);
         if (notoriousity_neg > notoriousity) {
             notoriousity = notoriousity_neg;
@@ -249,19 +249,19 @@ int c2_pick_most_notorious_literal(C2* c2) {
 }
 
 int_vector* c2_determine_notorious_determinsitic_variables(C2* c2) {
-    
+
     float notoriousity_threshold = c2_notoriousity_threshold(c2);
     int_vector* notorious_lits = int_vector_init();
-    
+
     for (unsigned i = 1; i < var_vector_count(c2->qcnf->vars); i++) {
         if (! skolem_is_deterministic(c2->skolem, i) || skolem_lit_satisfied(c2->skolem, (int) i) || skolem_lit_satisfied(c2->skolem, - (int) i)) {
             continue;
         }
-        
+
         float notoriousity_pos = c2_notoriousity(c2,   (int) i);
         float notoriousity_neg = c2_notoriousity(c2, - (int) i);
         int more_notorious_val = notoriousity_pos > notoriousity_neg ? 1 : -1; // cannot be notorious in both polarities
-        
+
         if ( (more_notorious_val > 0 && notoriousity_pos > notoriousity_threshold) || (more_notorious_val < 0 && notoriousity_neg > notoriousity_threshold) ) {
             V1("  Identified %d as notorious (%.3f).\n", - more_notorious_val * (int) i, notoriousity_pos > notoriousity_neg ? notoriousity_pos : notoriousity_neg );
             int_vector_add(notorious_lits, - more_notorious_val * (int) i);

--- a/src/c2_casesplits.c
+++ b/src/c2_casesplits.c
@@ -115,6 +115,7 @@ Lit c2_case_split_pick_literal(C2* c2) {
 }
 
 bool c2_case_split(C2* c2) {
+    assert(!skolem_can_propagate(c2->skolem));
 
     bool progress = false; // indicates whether this function call changed anything.
 

--- a/src/c2_casesplits.c
+++ b/src/c2_casesplits.c
@@ -77,7 +77,7 @@ unsigned c2_assume_constant(C2* c2, Lit lit) {
     assert(!skolem_can_propagate(c2->skolem));
     statistics_start_timer(c2->statistics.failed_literals_stats);
     
-    size_t propagations_start = c2->skolem->statistics.propagations;
+    size_t case_split_decision_metric = c2->skolem->statistics.propagations;
     
     skolem_push(c2->skolem);
     skolem_assume_constant_value(c2->skolem, lit);
@@ -86,26 +86,32 @@ unsigned c2_assume_constant(C2* c2, Lit lit) {
     if (skolem_is_conflicted(c2->skolem)) {
         V1("Skolem conflict with assumed constant %d: %d\n", lit, c2->skolem->conflict_var_id);
         c2->statistics.failed_literals_conflicts++;
+        case_split_decision_metric += 1024; //Magic number to ensure the variable is chosen
     }
     
-    V2("Number of propagations when assigning %d: %zu\n", lit, c2->skolem->statistics.propagations - propagations_start);
+    V2("Number of propagations when assigning %d: %zu\n", lit, c2->skolem->statistics.propagations - case_split_decision_metric);
     
     skolem_pop(c2->skolem);
     statistics_stop_and_record_timer(c2->statistics.failed_literals_stats);
     
-//    return ??
+    return case_split_decision_metric;
 }
 
 Lit c2_case_split_pick_literal(C2* c2) {
+    unsigned current_total, max_total = 0;
+    Lit lit = 0;
     for (unsigned i = 1; i < var_vector_count(c2->qcnf->vars); i++) {
         Var* v = var_vector_get(c2->qcnf->vars, i);
         if (v->var_id != 0 && skolem_is_deterministic(c2->skolem, i) && skolem_get_constant_value(c2->skolem, (Lit) v->var_id) == 0) {
-            
-            c2_assume_constant(c2, (Lit) v->var_id);
-            c2_assume_constant(c2, -(Lit) v->var_id);
+            current_total = c2_assume_constant(c2, (Lit) v->var_id) + c2_assume_constant(c2, -(Lit) v->var_id);
+            if (current_total > max_total) {
+                lit = v->var_id;
+                max_total = current_total;
+                if (max_total > 1024) break; // Magic number again, we found a failed literal
+            }
         }
     }
-    // return ??
+    return lit;
 }
 
 bool c2_case_split(C2* c2) {
@@ -115,73 +121,67 @@ bool c2_case_split(C2* c2) {
 //    Lit most_notorious_literal = c2_pick_most_notorious_literal(c2);
     Lit most_notorious_literal = c2_case_split_pick_literal(c2);
     if (most_notorious_literal != 0) {
-        float notoriousity = c2_notoriousity(c2, most_notorious_literal);
-        float threshold = c2_notoriousity_threshold(c2);
         c2->conflicts_between_case_splits_countdown = c2->conflicts_between_case_splits;
-        if (notoriousity > threshold) {
-            if (debug_verbosity >= VERBOSITY_LOW) {
-                V1("Found notorious literal");
-                options_print_literal_name(c2->options, c2_literal_color(c2, NULL, most_notorious_literal), most_notorious_literal);
-                V1(" with notoriousity %.2f; greater than threshold %.2f.\n", notoriousity, threshold);
-            }
+        if (debug_verbosity >= VERBOSITY_LOW) {
+            V1("Found notorious literal");
+            options_print_literal_name(c2->options, c2_literal_color(c2, NULL, most_notorious_literal), most_notorious_literal);
+            V1(" with notoriousity %.2f; greater than threshold %.2f.\n", notoriousity, threshold);
+        }
+        
+        satsolver_assume(c2->skolem->skolem, skolem_get_satsolver_lit(c2->skolem, most_notorious_literal));
+        
+        sat_res res = satsolver_sat(c2->skolem->skolem);
+        if (res != SATSOLVER_SATISFIABLE) {
+            V1("This case admits no assignments to the universals that are consistent with dlvl 0, switching polarity and assuming %d instead.\n", - most_notorious_literal);
+            
+            most_notorious_literal = - most_notorious_literal;
             
             satsolver_assume(c2->skolem->skolem, skolem_get_satsolver_lit(c2->skolem, most_notorious_literal));
-            
             sat_res res = satsolver_sat(c2->skolem->skolem);
-            if (res != SATSOLVER_SATISFIABLE) {
-                V1("This case admits no assignments to the universals that are consistent with dlvl 0, switching polarity and assuming %d instead.\n", - most_notorious_literal);
-                
-                most_notorious_literal = - most_notorious_literal;
-                
-                satsolver_assume(c2->skolem->skolem, skolem_get_satsolver_lit(c2->skolem, most_notorious_literal));
-                sat_res res = satsolver_sat(c2->skolem->skolem);
-                assert(c2->skolem->decision_lvl == c2->restart_base_decision_lvl);
-                if (res == SATSOLVER_UNSATISFIABLE) {
-                    V1("Also the SAT check of the other polarity failed. Exhausted the search space on the universal side.\n");
-                    assert(c2->result == CADET_RESULT_UNKNOWN);
-                    if (int_vector_count(c2->case_split_stack) == 0) {
-                        c2->result = CADET_RESULT_SAT;
-                    } else {
-                        abortif(! c2->options->cegar, "This case can only occur when something else fiddles with the assumptions.");
-                        V1("Case split successfully completed through CEGAR-Case Split interaction.\n");
-                        c2_backtrack_case_split(c2);
-                        c2_case_split_backtracking_heuristics(c2);
-                    }
-                    progress = true;
-                    most_notorious_literal = 0; // suppresses that case split happens
+            assert(c2->skolem->decision_lvl == c2->restart_base_decision_lvl);
+            if (res == SATSOLVER_UNSATISFIABLE) {
+                V1("Also the SAT check of the other polarity failed. Exhausted the search space on the universal side.\n");
+                assert(c2->result == CADET_RESULT_UNKNOWN);
+                if (int_vector_count(c2->case_split_stack) == 0) {
+                    c2->result = CADET_RESULT_SAT;
+                } else {
+                    abortif(! c2->options->cegar, "This case can only occur when something else fiddles with the assumptions.");
+                    V1("Case split successfully completed through CEGAR-Case Split interaction.\n");
+                    c2_backtrack_case_split(c2);
+                    c2_case_split_backtracking_heuristics(c2);
                 }
+                progress = true;
+                most_notorious_literal = 0; // suppresses that case split happens
+            }
+        }
+        
+        if (most_notorious_literal != 0) {
+            progress = true;
+            if (int_vector_count(c2->case_split_stack) == 0) {
+                c2->statistics.cases_explored += 1;
+                stack_push(c2->stack);
+                c2_push(c2);
+                c2->skolem->decision_lvl +=1;
+                c2->restart_base_decision_lvl += 1;
             }
             
-            if (most_notorious_literal != 0) {
-                progress = true;
-                if (int_vector_count(c2->case_split_stack) == 0) {
-                    c2->statistics.cases_explored += 1;
-                    stack_push(c2->stack);
-                    c2_push(c2);
-                    c2->skolem->decision_lvl +=1;
-                    c2->restart_base_decision_lvl += 1;
-                }
-                
-                int_vector_add(c2->case_split_stack, most_notorious_literal);
-                
-                assert(skolem_is_deterministic(c2->skolem, lit_to_var(most_notorious_literal)));
-                skolem_assume_constant_value(c2->skolem, most_notorious_literal);
-                
-                skolem_propagate(c2->skolem);
-                
-                if (skolem_is_conflicted(c2->skolem)) { // actual conflict
-                    assert(c2->skolem->decision_lvl == c2->restart_base_decision_lvl); // otherwise we need to go into conflict analysis
-                    V1("Case split lead to immediate conflict.\n");
-                    assert(c2->result == CADET_RESULT_UNKNOWN);
-                    c2->result = CADET_RESULT_UNSAT;
-                    c2->state = C2_SKOLEM_CONFLICT;
-                }
+            int_vector_add(c2->case_split_stack, most_notorious_literal);
+            
+            assert(skolem_is_deterministic(c2->skolem, lit_to_var(most_notorious_literal)));
+            skolem_assume_constant_value(c2->skolem, most_notorious_literal);
+            
+            skolem_propagate(c2->skolem);
+            
+            if (skolem_is_conflicted(c2->skolem)) { // actual conflict
+                assert(c2->skolem->decision_lvl == c2->restart_base_decision_lvl); // otherwise we need to go into conflict analysis
+                V1("Case split lead to immediate conflict.\n");
+                assert(c2->result == CADET_RESULT_UNKNOWN);
+                c2->result = CADET_RESULT_UNSAT;
+                c2->state = C2_SKOLEM_CONFLICT;
             }
-        } else {
-            V1("Case split not successful; notorious literal had only notoriousity %.2f; threshold was %.2f.\n", notoriousity, threshold);
         }
     } else {
-        V1("Case split not successful; no notorious variables detected.\n");
+        V1("Case split not successful; no failed literals detected.\n");
     }
     return progress;
 }

--- a/src/cadet2.c
+++ b/src/cadet2.c
@@ -774,6 +774,17 @@ cadet_res c2_sat(C2* c2) {
                 debug_print_histogram_of_activities(c2,false);
                 debug_print_histogram_of_activities(c2,true);
             }
+            
+            if (c2->options->case_splits
+//            && c2->restarts >= c2->magic.num_restarts_before_case_splits
+//            && c2->conflicts_between_case_splits_countdown == 0
+//            && c2->cases_explored == 0 // this limits the case splits to 1!!!
+            ) {
+                bool progress_through_case_split = c2_case_split(c2); //Does it serve any purpose to check this here? Was used to pass a decision in original use
+                if (c2->result != CADET_RESULT_UNKNOWN) { // either the above if statement or c2_case_split may result in SAT/UNSAT
+//                    return c2->result;    //This will result in an infinite loop as is, possibly something else to be done with this result?
+                }
+            }
         }
     }
     

--- a/src/cadet2.c
+++ b/src/cadet2.c
@@ -37,29 +37,29 @@ void c2_init_clauses_and_variables(C2* c2) {
 }
 
 C2* c2_init_qcnf(QCNF* qcnf, Options* options) {
-    
+
     C2* c2 = malloc(sizeof(C2));
-    
+
     c2->qcnf = qcnf;
     c2->options = options;
-    
+
     c2->decision_vals = val_vector_init();
     c2->state = C2_READY;
     c2->result = CADET_RESULT_UNKNOWN;
     c2->restarts = 0;
     c2->restart_base_decision_lvl = 0;
     c2->activity_factor = (float) 1.0;
-    
+
     c2->stack = stack_init(c2_undo);
-    
+
     // DOMAINS
     c2->skolem = skolem_init(c2->qcnf, options, vector_count(qcnf->scopes) + 1, 0);
     c2->examples = examples_init(qcnf, options->examples_max_num);
-    
+
     // Case splits
     c2->case_split_stack = int_vector_init();
     c2->decisions_since_last_conflict = 0;
-    
+
     // Statistics
     c2->statistics.conflicts = 0;
     c2->statistics.added_clauses = 0;
@@ -68,10 +68,10 @@ C2* c2_init_qcnf(QCNF* qcnf, Options* options) {
     c2->statistics.cases_explored = 0;
     c2->statistics.lvls_backtracked = 0;
     c2->statistics.start_time = get_seconds();
-    
+
     c2->statistics.failed_literals_stats = statistics_init(10000);
     c2->statistics.failed_literals_conflicts = 0;
-    
+
     // Magic constants
     c2->magic.initial_restart = 10; // [1..100] // depends also on restart factor
     c2->next_restart = c2->magic.initial_restart;
@@ -84,7 +84,7 @@ C2* c2_init_qcnf(QCNF* qcnf, Options* options) {
     c2->magic.major_restart_frequency = 20;
     c2->magic.num_restarts_before_Jeroslow_Wang = options->easy_debugging_mode_c2 ? 0 : 3;
     c2->magic.num_restarts_before_case_splits = 0; // options->easy_debugging_mode_c2 ? 0 : 5;
-    
+
     // Magic constants for case splits
     c2->magic.skolem_success_horizon = (float) 0.9; // >0.0 && <1.0
     c2->magic.notoriousity_threshold_factor = (float) 5.0; // > 0.0 ??
@@ -93,9 +93,9 @@ C2* c2_init_qcnf(QCNF* qcnf, Options* options) {
     c2->case_split_depth_penalty = C2_CASE_SPLIT_DEPTH_PENALTY_QUADRATIC;
     c2->conflicts_between_case_splits = options->easy_debugging_mode_c2 ? 0 : 10;
     c2->conflicts_between_case_splits_countdown = c2->conflicts_between_case_splits;
-    
+
     c2_init_clauses_and_variables(c2);
-    
+
     return c2;
 }
 
@@ -140,12 +140,12 @@ void c2_set_decision_val(C2* c2, unsigned var_id, int decision_val) {
     while (var_id >= val_vector_count(c2->decision_vals)) {
         val_vector_add(c2->decision_vals, 0);
     }
-    
+
     int old_val = val_vector_get(c2->decision_vals, var_id);
     int64_t data = (int64_t) var_id;
     data = data ^ ((int64_t) old_val << 32);
     stack_push_op(c2->stack, C2_OP_ASSIGN_DECISION_VAL, (void*) data);
-    
+
     val_vector_set(c2->decision_vals, var_id, decision_val);
 }
 
@@ -196,10 +196,10 @@ void c2_rescale_activity_values(C2* c2) {
 }
 
 void c2_initial_propagation(C2* c2) {
-    
+
     skolem_propagate(c2->skolem); // initial propagation for dlvl 0
     skolem_global_conflict_check(c2->skolem, false); // force conflict checks
-    
+
     if (!skolem_is_conflicted(c2->skolem)) {
         // Restrict the universals to always satisfy the constraints (derived from AIGER circuits)
         for (unsigned i = 0; i < int_vector_count(c2->qcnf->universals_constraints); i++) {
@@ -209,7 +209,7 @@ void c2_initial_propagation(C2* c2) {
             satsolver_clause_finished(c2->skolem->skolem);
             skolem_assume_constant_value(c2->skolem, (Lit) var_id);
         }
-        
+
         skolem_propagate(c2->skolem); // initial propagation may be extended after assuming constants for constraints
         skolem_global_conflict_check(c2->skolem, false); // force conflict checks
     }
@@ -217,23 +217,23 @@ void c2_initial_propagation(C2* c2) {
 
 void c2_replenish_skolem_satsolver(C2* c2) {
     V1("Replenishing satsolver\n");
-    
+
     // To be sure we did mess up we remember the skolem data structure's decision level and stack height
     assert(c2->skolem->decision_lvl == c2->restart_base_decision_lvl);
     unsigned old_skolem_dlvl = c2->skolem->decision_lvl;
     unsigned old_skolem_stack_height = c2->skolem->stack->push_count;
-    
+
     Skolem* old_skolem = c2->skolem;
-    
+
     c2->skolem = skolem_init(c2->qcnf,c2->options,vector_count(c2->qcnf->scopes),0);
     c2_init_clauses_and_variables(c2);
     c2_initial_propagation(c2);
     abortif(skolem_is_conflicted(c2->skolem), "Skolem domain was conflicted after replenishing.");
-    
+
     cegar_update_interface(c2->skolem);
-    
+
     assert(vector_count(old_skolem->cegar->solved_cubes) == 0 || c2->options->cegar || c2->options->case_splits);
-    
+
     // Now, we re-introduce the cubes that we have solved already.
     for (unsigned i = 0; i < vector_count(c2->skolem->cegar->solved_cubes); i++) {
         int_vector* cube = (int_vector*) vector_get(c2->skolem->cegar->solved_cubes, i);
@@ -245,9 +245,9 @@ void c2_replenish_skolem_satsolver(C2* c2) {
         }
         satsolver_clause_finished_for_context(c2->skolem->skolem, 0);
     }
-    
+
     skolem_free(old_skolem);
-    
+
     // make sure the skolem stack is on the right level
     while (c2->skolem->decision_lvl < c2->restart_base_decision_lvl) {
         skolem_push(c2->skolem);
@@ -259,7 +259,7 @@ void c2_replenish_skolem_satsolver(C2* c2) {
 
 void c2_restart_heuristics(C2* c2) {
     c2->next_restart = (unsigned) (c2->next_restart * c2->magic.restart_factor) + 1;
-    
+
     // Major or minor restart?
     if (c2->restarts % c2->magic.major_restart_frequency == c2->magic.major_restart_frequency - 1) {
         V1("Major restart. Resetting all activity values to 0 and some random ones to 1.\n");
@@ -275,7 +275,7 @@ void c2_restart_heuristics(C2* c2) {
                 c2_increase_activity(c2, random_var_id, 1.0f/(float) i);
             }
         }
-        
+
 #if (USE_SOLVER == SOLVER_PICOSAT_ASSUMPTIONS) // This is a workaround for an annoying bug in picosat
         c2_replenish_skolem_satsolver(c2);
 #endif
@@ -330,7 +330,7 @@ unsigned c2_are_decisions_involved(C2* c2, int_vector* conflict) {
         PartialAssignment* pa = examples_get_conflicted_assignment(c2->examples);
         max_decision_lvl = pa->decision_lvl;
     }
-    
+
     for (unsigned i = 0; i < int_vector_count(conflict); i++) {
         Lit lit = int_vector_get(conflict, i);
         unsigned dlvl;
@@ -341,7 +341,7 @@ unsigned c2_are_decisions_involved(C2* c2, int_vector* conflict) {
             PartialAssignment* pa = examples_get_conflicted_assignment(c2->examples);
             dlvl = partial_assignment_get_decision_lvl(pa, lit_to_var(lit));
         }
-        
+
         if (dlvl > largest_decision_level_involved) {
             largest_decision_level_involved = dlvl;
         }
@@ -353,7 +353,7 @@ unsigned c2_are_decisions_involved(C2* c2, int_vector* conflict) {
     return largest_decision_level_involved > c2->restart_base_decision_lvl;
 }
 
-// Returns the second largest decision level that occurs in the conflict. If no second largest decision level exists, returns 0. 
+// Returns the second largest decision level that occurs in the conflict. If no second largest decision level exists, returns 0.
 unsigned c2_determine_backtracking_lvl(C2* c2, int_vector* conflict) {
     int_vector* dlvls = int_vector_init();
     V2("Decision lvls in conflicted domain:");
@@ -372,9 +372,9 @@ unsigned c2_determine_backtracking_lvl(C2* c2, int_vector* conflict) {
         int_vector_add(dlvls, (int) dlvl);
     }
     V2("\n");
-    
+
     int_vector_sort(dlvls, compare_integers_natural_order);
-    
+
     while (int_vector_count(dlvls) >= 2 &&
            int_vector_get(dlvls, int_vector_count(dlvls) - 1) == int_vector_get(dlvls, int_vector_count(dlvls) - 2)) {
         int_vector_remove_index(dlvls, int_vector_count(dlvls) - 1);
@@ -429,19 +429,19 @@ float c2_Jeroslow_Wang_log_weight(vector* clauses) {
 
 // MAIN LOOPS
 cadet_res c2_run(C2* c2, unsigned remaining_conflicts) {
-    
+
     while (remaining_conflicts > 0) {
         V4("\nEntering main loop at dlvl %u.\n", c2->skolem->decision_lvl);
-        
+
         assert(c2->state == C2_READY);
         assert(c2->skolem->decision_lvl >= c2->restart_base_decision_lvl);
         assert(c2->skolem->decision_lvl <= c2->stack->push_count);
         assert(c2->qcnf->stack->push_count >= c2->skolem->stack->push_count);
         assert(c2->skolem->stack->push_count >= c2->skolem->decision_lvl - c2->restart_base_decision_lvl);
-        
+
         int_vector* conflict = NULL;
         unsigned conflicted_var_id = 0;
-        
+
         examples_propagate(c2->examples);
         if (examples_is_conflicted(c2->examples)) {
             assert(c2->state == C2_READY);
@@ -458,7 +458,7 @@ cadet_res c2_run(C2* c2, unsigned remaining_conflicts) {
             conflicted_var_id = 0;
         } else {
             skolem_propagate(c2->skolem);
-            
+
             if (skolem_is_conflicted(c2->skolem)) {
                 assert(c2->state == C2_READY);
                 c2->state = C2_SKOLEM_CONFLICT;
@@ -474,18 +474,18 @@ cadet_res c2_run(C2* c2, unsigned remaining_conflicts) {
             }
         }
         if (conflict != NULL) {
-            
+
             c2_print_variable_states(c2);
-            
+
             remaining_conflicts -= 1;
             c2->statistics.conflicts += 1;
             float conflict_success_rating = (float) 1.0 / (((float) int_vector_count(conflict)) * ((float) c2->decisions_since_last_conflict) + (float) 1.0);
             c2->skolem_success_recent_average = (float) (c2->skolem_success_recent_average * c2->magic.skolem_success_horizon + conflict_success_rating * (1.0 - c2->magic.skolem_success_horizon));
             c2->decisions_since_last_conflict = 0;
-            
+
             if (c2_are_decisions_involved(c2,conflict)) { // any decisions involved?
                 abortif(c2->statistics.decisions == 0, "Huh?");
-                
+
                 // Update Examples database
                 PartialAssignment* new_example = NULL;
                 if (c2->skolem->state == SKOLEM_STATE_SKOLEM_CONFLICT) {
@@ -497,7 +497,7 @@ cadet_res c2_run(C2* c2, unsigned remaining_conflicts) {
                         return c2->result;
                     }
                 }
-                
+
                 // Update CEGAR abstraction // TODO: Move this into skolem.c in the conflict check.
                 if (c2->options->cegar && c2->skolem->state == SKOLEM_STATE_SKOLEM_CONFLICT) {
                     if (cegar_build_abstraction_for_assignment(c2) != CADET_RESULT_UNKNOWN) {
@@ -505,60 +505,60 @@ cadet_res c2_run(C2* c2, unsigned remaining_conflicts) {
                         return c2->result;
                     }
                 }
-                
+
                 unsigned backtracking_lvl = c2_determine_backtracking_lvl(c2, conflict); // was equal to largest_decision_lvl_involved (-1?)
                 unsigned old_dlvl = c2->skolem->decision_lvl;
                 c2_backtrack_to_decision_lvl(c2, backtracking_lvl);
-                
+
                 if (c2->conflicts_between_case_splits_countdown > 0)
                     c2->conflicts_between_case_splits_countdown--;
-                
-                
+
+
                 for (unsigned i = 0; i < int_vector_count(conflict); i++) {
                     int lit = int_vector_get(conflict, i);
                     c2_add_lit(c2, - lit);
                 }
                 Clause* learnt_clause = qcnf_close_clause(c2->qcnf);
-                
+
                 abortif(learnt_clause == NULL, "Conflict clause could not be created. Conflict counter: %zu", c2->statistics.conflicts);
-                
+
                 learnt_clause->original = false;
                 learnt_clause->consistent_with_originals = true;
                 assert(skolem_get_unique_consequence(c2->skolem, learnt_clause) == 0);
-                
+
                 if (new_example) {
                     examples_redo(c2->examples, c2->skolem, new_example);
                 }
                 examples_new_clause(c2->examples, learnt_clause);
-                
+
                 if (skolem_get_unique_consequence(c2->skolem, learnt_clause) != 0) {
                     skolem_bump_conflict_potential(c2->skolem, lit_to_var(skolem_get_unique_consequence(c2->skolem, learnt_clause)));
                 }
-                
+
                 if (debug_verbosity >= VERBOSITY_MEDIUM || c2->options->trace_learnt_clauses) {
                     c2_log_clause(c2, learnt_clause);
                 }
                 c2_new_clause(c2, learnt_clause);
-                
+
                 c2_conflict_heuristics(c2, learnt_clause, conflicted_var_id);
-                
+
                 V1("Learnt clause has length %u. Backtracking %u lvls to lvl %u\n", learnt_clause->size, old_dlvl - c2->skolem->decision_lvl, c2->skolem->decision_lvl);
                 c2->statistics.lvls_backtracked += old_dlvl - c2->skolem->decision_lvl;
 #ifdef DEBUG
                 c2_validate_unique_consequences(c2);
 #endif
                 c2_trace_for_profiling(c2);
-                
+
                 int_vector_free(conflict);
-                
+
                 c2->state = C2_READY;
-                
+
             } else { // actual conflict
                 if (c2->options->functional_synthesis && int_vector_count(conflict) > 0) {
-                    
+
                     c2_backtrack_to_decision_lvl(c2, c2->restart_base_decision_lvl);
                     c2->state = C2_READY;
-                    
+
                     V2("Functional synthesis exludes cube:");
                     for (unsigned i = 0; i < int_vector_count(conflict); i++) {
                         int lit = int_vector_get(conflict, i);
@@ -572,23 +572,23 @@ cadet_res c2_run(C2* c2, unsigned remaining_conflicts) {
                     V1("Functional synthesis detected a cube of length %u that is over dlvl0 only. We exclude it from future conflict checks.\n", int_vector_count(conflict));
                     continue;
                 }
-                
+
                 if (debug_verbosity >= VERBOSITY_LOW) {
                     c2_print_universals_assignment(c2);
                 }
-                
+
                 assert(c2->result == CADET_RESULT_UNKNOWN);
                 c2->result = CADET_RESULT_UNSAT;
                 return c2->result;
             }
-            
+
         } else { // conflict == NULL
             // Not in conflict state. Now case splits and decisions are needed to make further progress.
-            
+
             if (skolem_can_propagate(c2->skolem)) {
                 continue; // can happen when a potentially conflicted variable is not actually conflicted
             }
-            
+
             if (c2->options->case_splits
                 && (! c2->options->case_splits_only_at_decision_level_0 || c2->skolem->decision_lvl == c2->restart_base_decision_lvl)
 //                && c2->decisions_since_last_conflict == 0
@@ -606,12 +606,12 @@ cadet_res c2_run(C2* c2, unsigned remaining_conflicts) {
                     continue;
                 } // Else continue picking a decision variable. Avoids runnint into a loop where case distinction is tried but nothing happens.
             }
-            
+
             assert(!skolem_can_propagate(c2->skolem));
-            
+
             // regular decision
             Var* decision_var = c2_pick_most_active_notdeterministic_variable(c2);
-            
+
             if (decision_var == NULL) { // no variable could be found
                 if (int_vector_count(c2->skolem->potentially_conflicted_variables) == 0) {
                     if (int_vector_count(c2->case_split_stack) == 0) {
@@ -629,30 +629,30 @@ cadet_res c2_run(C2* c2, unsigned remaining_conflicts) {
                 } else {
                     skolem_global_conflict_check(c2->skolem, false);
                 }
-                
+
             } else { // take a decision
                 assert(!skolem_is_conflicted(c2->skolem));
-                
+
                 int phase = 1;
                 if (c2->restarts >= c2->magic.num_restarts_before_Jeroslow_Wang) {
-				
+
                     float pos_JW_weight = c2_Jeroslow_Wang_log_weight(&decision_var->pos_occs);
                     float neg_JW_weight = c2_Jeroslow_Wang_log_weight(&decision_var->neg_occs);
-				
+
                     phase = pos_JW_weight > neg_JW_weight ? 1 : -1;
                 }
-                
+
                 c2_scale_activity(c2, decision_var->var_id, c2->magic.decision_var_activity_modifier);
-                
+
                 // Pushing before the actual decision is important to keep things
                 // clean (think of decisions on level 0). This is not a decision yet,
                 // so decision_lvl is not yet increased.
                 stack_push(c2->stack);
                 c2_push(c2);
-                
+
                 c2->statistics.decisions += 1;
                 c2->decisions_since_last_conflict += 1;
-                
+
                 // examples_decision(c2->examples, value * (Lit) decision_var_id);
                 examples_decision_consistent_with_skolem(c2->examples, c2->skolem, phase * (Lit) decision_var->var_id);
                 if (examples_is_conflicted(c2->examples)) {
@@ -663,10 +663,10 @@ cadet_res c2_run(C2* c2, unsigned remaining_conflicts) {
                     c2_set_decision_val(c2, decision_var->var_id, phase);
                 }
             }
-            
+
         }
     }
-    
+
     abortif(c2->result != CADET_RESULT_UNKNOWN, "Expected going into restart but result is not unknown.");
     c2_backtrack_to_decision_lvl(c2, c2->restart_base_decision_lvl);
     return c2->result; // results in a restart
@@ -693,18 +693,18 @@ cadet_res c2_check_propositional(QCNF* qcnf) {
 
 
 cadet_res c2_sat(C2* c2) {
-    
+
     if (c2->result != CADET_RESULT_UNKNOWN) {
         return c2->result;
     }
-    
+
     if (c2->qcnf->empty_clause != NULL) {
         V1("CNF contains an empty clause (clause id %u).\n", c2->qcnf->empty_clause->clause_id);
         c2->result = CADET_RESULT_UNSAT;
         c2->state = C2_EMPTY_CLAUSE_CONFLICT;
         return CADET_RESULT_UNSAT;
     }
-    
+
     if (qcnf_is_propositional(c2->qcnf) && ! c2->options->use_qbf_engine_also_for_propositional_problems) {
         c2->result = c2_check_propositional(c2->qcnf);
         if (c2->result == CADET_RESULT_UNSAT) {
@@ -712,23 +712,23 @@ cadet_res c2_sat(C2* c2) {
         }
         return c2->result;
     }
-    
+
     ////// THIS RESTRICTS US TO 2QBF
     if (! qcnf_is_2QBF(c2->qcnf) && ! qcnf_is_propositional(c2->qcnf)) {
         V0("Is not 2QBF. Currently not supported.\n");
         return CADET_RESULT_UNKNOWN;
     }
     //////
-    
+
     c2_initial_propagation(c2);
-    
+
     if (!skolem_is_conflicted(c2->skolem)) {
         if (c2->options->miniscoping) {
             c2_analysis_determine_number_of_partitions(c2);
         }
-        
+
         cegar_update_interface(c2->skolem);
-        
+
         if (c2->options->cegar_only) {
             return cegar_solve_2QBF(c2, -1);
         }
@@ -738,7 +738,7 @@ cadet_res c2_sat(C2* c2) {
             return c2->result;
         }
     }
-    
+
     for (unsigned i = 0; i < c2->options->initial_examples; i ++) {
         PartialAssignment* pa = examples_add_random_assignment(c2->examples);
         if (pa && partial_assignment_is_conflicted(pa)) {
@@ -750,7 +750,7 @@ cadet_res c2_sat(C2* c2) {
         c2->state = C2_EXAMPLES_CONFLICT;
         return c2->result;
     }
-    
+
     if (debug_verbosity >= VERBOSITY_MEDIUM) {
         V1("Deterministic vars on dlvl 0 are:");
         for (unsigned i = 0; i < var_vector_count(c2->qcnf->vars); i++) {
@@ -760,34 +760,31 @@ cadet_res c2_sat(C2* c2) {
         }
         V0("\n");
     }
-    
+
     while (c2->result == CADET_RESULT_UNKNOWN) { // This loop controls the restarts
         c2_run(c2, c2->next_restart);
-        
+
         if (c2->result == CADET_RESULT_UNKNOWN) {
             V2("Restart %zu\n", c2->restarts);
             assert(c2->skolem->decision_lvl == c2->restart_base_decision_lvl);
             c2->restarts += 1;
             c2_restart_heuristics(c2);
-            
+
             if (debug_verbosity >= VERBOSITY_MEDIUM) {
                 debug_print_histogram_of_activities(c2,false);
                 debug_print_histogram_of_activities(c2,true);
             }
-            
+
             if (c2->options->case_splits
 //            && c2->restarts >= c2->magic.num_restarts_before_case_splits
 //            && c2->conflicts_between_case_splits_countdown == 0
 //            && c2->cases_explored == 0 // this limits the case splits to 1!!!
             ) {
-                bool progress_through_case_split = c2_case_split(c2); //Does it serve any purpose to check this here? Was used to pass a decision in original use
-                if (c2->result != CADET_RESULT_UNKNOWN) { // either the above if statement or c2_case_split may result in SAT/UNSAT
-//                    return c2->result;    //This will result in an infinite loop as is, possibly something else to be done with this result?
-                }
+                c2_case_split(c2); //Does it serve any purpose to check this here? Was used to pass a decision in original use
             }
         }
     }
-    
+
     return c2->result;
 }
 
@@ -798,24 +795,24 @@ cadet_res c2_solve_qdimacs(FILE* f, Options* options) {
     QCNF* qcnf = create_qcnf_from_file(f, options);
     fclose(f);
     abortif(!qcnf,"Failed to create QCNF.");
-    
+
     if (options->print_qdimacs) {
         qcnf_print_qdimacs(qcnf);
         return 1;
     }
-    
+
     V1("Maximal variable index: %u\n", var_vector_count(qcnf->vars));
     V1("Number of clauses: %u\n", vector_count(qcnf->clauses));
     V1("Number of scopes: %u\n", vector_count(qcnf->scopes));
-    
+
     C2* c2 = c2_init_qcnf(qcnf, options);
-    
+
     c2_sat(c2);
-    
+
     if (debug_verbosity >= VERBOSITY_LOW) {
         c2_print_statistics(c2);
     }
-    
+
     switch (c2->result) {
         case CADET_RESULT_UNKNOWN:
             V0("UNKNOWN\n");
@@ -833,7 +830,7 @@ cadet_res c2_solve_qdimacs(FILE* f, Options* options) {
             }
             break;
     }
-    
+
     if (c2->result == CADET_RESULT_SAT && c2->options->certify_SAT) {
         c2_cert_AIG_certificate(c2);
     }
@@ -868,7 +865,7 @@ cadet_res c2_solve_qdimacs(FILE* f, Options* options) {
             V1("Result verified.\n");
         }
     }
-    
+
     return c2->result;
 }
 
@@ -885,16 +882,16 @@ void c2_pop(C2* c2) {
 void c2_undo(void* parent, char type, void* obj) {
     C2* c2 = (C2*) parent;
     unsigned var_id = (unsigned) (int64_t) obj; // is 0 in case of type == C2_OP_CASE_SPLIT
-    
+
     switch ((C2_OPERATION) type) {
-            
+
         case C2_OP_ASSIGN_DECISION_VAL:
             assert(true);
             int old_val = (int) ((size_t) obj >> 32);
             assert(old_val <= 1 && old_val >= -1);
             val_vector_set(c2->decision_vals, var_id, old_val);
             break;
-            
+
         default:
             V0("Unknown undo operation in cadet2.c.\n");
             NOT_IMPLEMENTED();
@@ -918,13 +915,13 @@ void c2_new_variable(C2* c2, unsigned var_id) {
     Var* v = var_vector_get(c2->qcnf->vars, var_id);
     if (v->var_id != 0 && skolem_is_initially_deterministic(c2->skolem, var_id)) {
         assert(var_id == v->var_id);
-        
+
         skolem_update_deterministic(c2->skolem, var_id, 1);
-        
+
         int innerlit = satsolver_inc_max_var(c2->skolem->skolem);
         skolem_update_pos_lit(c2->skolem, var_id, innerlit);
         skolem_update_neg_lit(c2->skolem, var_id, - innerlit);
-        
+
         union Dependencies dep;
         if (!qcnf_is_DQBF(c2->qcnf)) {
             dep.dependence_lvl = v->scope_id;
@@ -933,7 +930,7 @@ void c2_new_variable(C2* c2, unsigned var_id) {
             int_vector_add(dep.dependencies, (int) v->var_id);
         }
         skolem_update_dependencies(c2->skolem, var_id, dep);
-        
+
         if (v->is_universal) {
             skolem_update_universal(c2->skolem, var_id, 1);
         }

--- a/src/options.c
+++ b/src/options.c
@@ -11,24 +11,24 @@
 
 Options* default_options() {
     Options* o = malloc(sizeof(Options));
-    
+
     o->easy_debugging_mode_c2 = false;
 
     // Computational enginges
-    o->cegar = true;
+    o->cegar = false;
     o->cegar_only = false;
     o->delay_conflict_checks = false;
     o->use_qbf_engine_also_for_propositional_problems = false;
     o->functional_synthesis = false;
-    
+
     // Examples domain
     o->examples_max_num = 0; // 0 corresponds to not doing examples at all
     o->initial_examples = 0;
-    
+
     // Aiger interpretations
     o->aiger_controllable_inputs = "pi_"; // "controllable_";
     o->aiger_negated_encoding = false;
-    
+
     // Certificates
     o->certify_internally_UNSAT = true;
     o->certify_UNSAT = false;
@@ -36,11 +36,11 @@ Options* default_options() {
     o->certificate_file_name = NULL;
     o->certificate_type = CAQECERT;
     o->certificate_aiger_mode = aiger_ascii_mode;
-    
+
     // Case splits
-    o->case_splits = false;
+    o->case_splits = true;
     o->case_splits_only_at_decision_level_0 = true;
-    
+
     // Optimizations
     o->miniscoping = false;
     o->find_smallest_reason = true;
@@ -50,18 +50,18 @@ Options* default_options() {
     o->propagate_pure_literals = true;
     o->enhanced_pure_literals = false;
     o->failed_literals = false;
-    
+
     // Printing
     o->print_detailed_miniscoping_stats = false;
     o->print_name_mapping = true;
     o->print_statistics = true;
     o->print_qdimacs = false;
     o->variable_names = NULL;
-    
+
     o->trace_learnt_clauses = false;
     o->trace_for_visualization = false;
     o->trace_for_profiling = false;
-    
+
     return o;
 }
 


### PR DESCRIPTION
The test cases all pass when case splits are off, but when forced on by default, only the eequery integration test fails whereas it normally times out. Possibly an improvement?