### PR TITLE
add missing import of time.h

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -14,6 +14,7 @@
 #include <assert.h>
 #include <stdint.h>
 #include <errno.h>
+#include <time.h>
 
 int compare_integers_abs(const void * a, const void * b) {
     int x = abs(* ((int*) a));


### PR DESCRIPTION
The missing import causes this warning/error on macOS 10.15.6 & Apple clang version 12.0.0 (clang-1200.0.32.2):
```
src/util.c:123:18: error: implicit declaration of function 'nanosleep' is invalid in C99
      [-Werror,-Wimplicit-function-declaration]
        result = nanosleep(&ts_sleep, &ts_remaining);
```