### PR TITLE
Fixing compilation

### DIFF
--- a/src/log.h
+++ b/src/log.h
@@ -36,10 +36,10 @@
 #define KORANGE  "\x1B[38;5;202m"
 #define KORANGE_BOLD  "\x1B[01;38;5;202m"
 
-int debug_verbosity;
-bool log_qdimacs_compliant;
-bool log_colors;
-bool log_silent;
+extern int debug_verbosity;
+extern bool log_qdimacs_compliant;
+extern bool log_colors;
+extern bool log_silent;
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"


### PR DESCRIPTION
This fixes compilation issues:

```
gcc -O3 -DNDEBUG -std=c11   ./src/active_clause_iterator.o  ./src/aiger.o  ./src/aiger_utils.o  ./src/bit_vector.o  ./src/c2_casesplits_control.o  ./src/c2_clause_minimization.o  ./src/c2_rl.o  ./src/c2_simplify.o  ./src/c2_traces.o  ./src/c2_validate.o  ./src/cadet2.o  ./src/casesplits.o  ./src/cegar.o  ./src/certify_SAT.o  ./src/certify_UNSAT.o  ./src/certify_validate.o  ./src/conflict_analysis.o  ./src/debug.o  ./src/examples.o  ./src/float_vector.o  ./src/heap.o  ./src/int_vector.o  ./src/log.o  ./src/main.o  ./src/map.o  ./src/mersenne_twister.o  ./src/options.o  ./src/parse.o  ./src/partial_assignment.o  ./src/partitions.o  ./src/picosat.o  ./src/pqueue.o  ./src/qcnf.o  ./src/qcnf_variable_names.o  ./src/qipasir.o  ./src/qipasir_parser.o  ./src/satsolver_lingeling_assumptions.o  ./src/satsolver_picosat_assumptions.o  ./src/satsolver_picosat.o  ./src/set.o  ./src/skolem.o  ./src/skolem_conflict_analysis.o  ./src/skolem_dependencies.o  ./src/skolem_var.o  ./src/skolem_var_vector.o  ./src/statistics.o  ./src/tests.o  ./src/undo_stack.o  ./src/util.o  ./src/val_vector.o  ./src/var_vector.o  ./src/vector.o  ./src/lingeling/lglib.o  ./src/lingeling/lglopts.o  ./src/satsolver_minisat.o -lm -lstdc++ -o cadet
/usr/bin/ld: ./src/c2_casesplits_control.o:(.bss+0x4): multiple definition of `debug_verbosity'; ./src/aiger_utils.o:(.bss+0x4): first defined here
/usr/bin/ld: ./src/c2_casesplits_control.o:(.bss+0x0): multiple definition of `log_silent'; ./src/aiger_utils.o:(.bss+0x0): first defined here
/usr/bin/ld: ./src/c2_casesplits_control.o:(.bss+0x1): multiple definition of `log_colors'; ./src/aiger_utils.o:(.bss+0x1): first defined here
/usr/bin/ld: ./src/c2_casesplits_control.o:(.bss+0x2): multiple definition of `log_qdimacs_compliant'; ./src/aiger_utils.o:(.bss+0x2): first defined here
/usr/bin/ld: ./src/c2_clause_minimization.o:(.bss+0x4): multiple definition of `debug_verbosity'; ./src/aiger_utils.o:(.bss+0x4): first defined here
/usr/bin/ld: ./src/c2_clause_minimization.o:(.bss+0x0): multiple definition of `log_silent'; ./src/aiger_utils.o:(.bss+0x0): first defined here
/usr/bin/ld: ./src/c2_clause_minimization.o:(.bss+0x2): multiple definition of `log_qdimacs_compliant'; ./src/aiger_utils.o:(.bss+0x2): first defined here
/usr/bin/ld: ./src/c2_clause_minimization.o:(.bss+0x1): multiple definition of `log_colors'; ./src/aiger_utils.o:(.bss+0x1): first defined here
/usr/bin/ld: ./src/c2_rl.o:(.bss+0x21): multiple definition of `log_colors'; ./src/aiger_utils.o:(.bss+0x1): first defined here
/usr/bin/ld: ./src/c2_rl.o:(.bss+0x20): multiple definition of `log_silent'; ./src/aiger_utils.o:(.bss+0x0): first defined here
/usr/bin/ld: ./src/c2_rl.o:(.bss+0x22): multiple definition of `log_qdimacs_compliant'; ./src/aiger_utils.o:(.bss+0x2): first defined here
/usr/bin/ld: ./src/c2_rl.o:(.bss+0x24): multiple definition of `debug_verbosity'; ./src/aiger_utils.o:(.bss+0x4): first defined here
/usr/bin/ld: ./src/c2_simplify.o:(.bss+0x4): multiple definition of `debug_verbosity'; ./src/aiger_utils.o:(.bss+0x4): first defined here
/usr/bin/ld: ./src/c2_simplify.o:(.bss+0x0): multiple definition of `log_silent'; ./src/aiger_utils.o:(.bss+0x0): first defined here
/usr/bin/ld: ./src/c2_simplify.o:(.bss+0x2): multiple definition of `log_qdimacs_compliant'; ./src/aiger_utils.o:(.bss+0x2): first defined here
/usr/bin/ld: ./src/c2_simplify.o:(.bss+0x1): multiple definition of `log_colors'; ./src/aiger_utils.o:(.bss+0x1): first defined here
/usr/bin/ld: ./src/c2_traces.o:(.bss+0x11): multiple definition of `log_silent'; ./src/aiger_utils.o:(.bss+0x0): first defined here
/usr/bin/ld: ./src/c2_traces.o:(.bss+0x13): multiple definition of `log_qdimacs_compliant'; ./src/aiger_utils.o:(.bss+0x2): first defined here
/usr/bin/ld: ./src/c2_traces.o:(.bss+0x12): multiple definition of `log_colors'; ./src/aiger_utils.o:(.bss+0x1): first defined here
/usr/bin/ld: ./src/c2_traces.o:(.bss+0x14): multiple definition of `debug_verbosity'; ./src/aiger_utils.o:(.bss+0x4): first defined here
/usr/bin/ld: ./src/c2_validate.o:(.bss+0x1): multiple definition of `log_colors'; ./src/aiger_utils.o:(.bss+0x1): first defined here
/usr/bin/ld: ./src/c2_validate.o:(.bss+0x0): multiple definition of `log_silent'; ./src/aiger_utils.o:(.bss+0x0): first defined here
/usr/bin/ld: ./src/c2_validate.o:(.bss+0x2): multiple definition of `log_qdimacs_compliant'; ./src/aiger_utils.o:(.bss+0x2): first defined here
/usr/bin/ld: ./src/c2_validate.o:(.bss+0x4): multiple definition of `debug_verbosity'; ./src/aiger_utils.o:(.bss+0x4): first defined here
/usr/bin/ld: ./src/cadet2.o:(.bss+0x1): multiple definition of `log_colors'; ./src/aiger_utils.o:(.bss+0x1): first defined here
/usr/bin/ld: ./src/cadet2.o:(.bss+0x0): multiple definition of `log_silent'; ./src/aiger_utils.o:(.bss+0x0): first defined here
/usr/bin/ld: ./src/cadet2.o:(.bss+0x2): multiple definition of `log_qdimacs_compliant'; ./src/aiger_utils.o:(.bss+0x2): first defined here
/usr/bin/ld: ./src/cadet2.o:(.bss+0x4): multiple definition of `debug_verbosity'; ./src/aiger_utils.o:(.bss+0x4): first defined here
/usr/bin/ld: ./src/casesplits.o:(.bss+0x4): multiple definition of `debug_verbosity'; ./src/aiger_utils.o:(.bss+0x4): first defined here
/usr/bin/ld: ./src/casesplits.o:(.bss+0x0): multiple definition of `log_silent'; ./src/aiger_utils.o:(.bss+0x0): first defined here
/usr/bin/ld: ./src/casesplits.o:(.bss+0x2): multiple definition of `log_qdimacs_compliant'; ./src/aiger_utils.o:(.bss+0x2): first defined here
/usr/bin/ld: ./src/casesplits.o:(.bss+0x1): multiple definition of `log_colors'; ./src/aiger_utils.o:(.bss+0x1): first defined here
/usr/bin/ld: ./src/cegar.o:(.bss+0x1): multiple definition of `log_colors'; ./src/aiger_utils.o:(.bss+0x1): first defined here
/usr/bin/ld: ./src/cegar.o:(.bss+0x0): multiple definition of `log_silent'; ./src/aiger_utils.o:(.bss+0x0): first defined here
/usr/bin/ld: ./src/cegar.o:(.bss+0x2): multiple definition of `log_qdimacs_compliant'; ./src/aiger_utils.o:(.bss+0x2): first defined here
/usr/bin/ld: ./src/cegar.o:(.bss+0x4): multiple definition of `debug_verbosity'; ./src/aiger_utils.o:(.bss+0x4): first defined here
/usr/bin/ld: ./src/certify_SAT.o:(.bss+0x4): multiple definition of `debug_verbosity'; ./src/aiger_utils.o:(.bss+0x4): first defined here
/usr/bin/ld: ./src/certify_SAT.o:(.bss+0x0): multiple definition of `log_silent'; ./src/aiger_utils.o:(.bss+0x0): first defined here
/usr/bin/ld: ./src/certify_SAT.o:(.bss+0x2): multiple definition of `log_qdimacs_compliant'; ./src/aiger_utils.o:(.bss+0x2): first defined here
/usr/bin/ld: ./src/certify_SAT.o:(.bss+0x1): multiple definition of `log_colors'; ./src/aiger_utils.o:(.bss+0x1): first defined here
/usr/bin/ld: ./src/certify_UNSAT.o:(.bss+0x0): multiple definition of `log_silent'; ./src/aiger_utils.o:(.bss+0x0): first defined here
/usr/bin/ld: ./src/certify_UNSAT.o:(.bss+0x2): multiple definition of `log_qdimacs_compliant'; ./src/aiger_utils.o:(.bss+0x2): first defined here
/usr/bin/ld: ./src/certify_UNSAT.o:(.bss+0x1): multiple definition of `log_colors'; ./src/aiger_utils.o:(.bss+0x1): first defined here
/usr/bin/ld: ./src/certify_UNSAT.o:(.bss+0x4): multiple definition of `debug_verbosity'; ./src/aiger_utils.o:(.bss+0x4): first defined here
/usr/bin/ld: ./src/certify_validate.o:(.bss+0x0): multiple definition of `log_silent'; ./src/aiger_utils.o:(.bss+0x0): first defined here
/usr/bin/ld: ./src/certify_validate.o:(.bss+0x2): multiple definition of `log_qdimacs_compliant'; ./src/aiger_utils.o:(.bss+0x2): first defined here
/usr/bin/ld: ./src/certify_validate.o:(.bss+0x1): multiple definition of `log_colors'; ./src/aiger_utils.o:(.bss+0x1): first defined here
/usr/bin/ld: ./src/certify_validate.o:(.bss+0x4): multiple definition of `debug_verbosity'; ./src/aiger_utils.o:(.bss+0x4): first defined here
/usr/bin/ld: ./src/conflict_analysis.o:(.bss+0x4): multiple definition of `debug_verbosity'; ./src/aiger_utils.o:(.bss+0x4): first defined here
/usr/bin/ld: ./src/conflict_analysis.o:(.bss+0x0): multiple definition of `log_silent'; ./src/aiger_utils.o:(.bss+0x0): first defined here
/usr/bin/ld: ./src/conflict_analysis.o:(.bss+0x2): multiple definition of `log_qdimacs_compliant'; ./src/aiger_utils.o:(.bss+0x2): first defined here
/usr/bin/ld: ./src/conflict_analysis.o:(.bss+0x1): multiple definition of `log_colors'; ./src/aiger_utils.o:(.bss+0x1): first defined here
/usr/bin/ld: ./src/debug.o:(.bss+0x4): multiple definition of `debug_verbosity'; ./src/aiger_utils.o:(.bss+0x4): first defined here
/usr/bin/ld: ./src/debug.o:(.bss+0x0): multiple definition of `log_silent'; ./src/aiger_utils.o:(.bss+0x0): first defined here
/usr/bin/ld: ./src/debug.o:(.bss+0x2): multiple definition of `log_qdimacs_compliant'; ./src/aiger_utils.o:(.bss+0x2): first defined here
/usr/bin/ld: ./src/debug.o:(.bss+0x1): multiple definition of `log_colors'; ./src/aiger_utils.o:(.bss+0x1): first defined here
/usr/bin/ld: ./src/examples.o:(.bss+0x1): multiple definition of `log_colors'; ./src/aiger_utils.o:(.bss+0x1): first defined here
/usr/bin/ld: ./src/examples.o:(.bss+0x0): multiple definition of `log_silent'; ./src/aiger_utils.o:(.bss+0x0): first defined here
/usr/bin/ld: ./src/examples.o:(.bss+0x2): multiple definition of `log_qdimacs_compliant'; ./src/aiger_utils.o:(.bss+0x2): first defined here
/usr/bin/ld: ./src/examples.o:(.bss+0x4): multiple definition of `debug_verbosity'; ./src/aiger_utils.o:(.bss+0x4): first defined here
/usr/bin/ld: ./src/float_vector.o:(.bss+0x1): multiple definition of `log_colors'; ./src/aiger_utils.o:(.bss+0x1): first defined here
/usr/bin/ld: ./src/float_vector.o:(.bss+0x0): multiple definition of `log_silent'; ./src/aiger_utils.o:(.bss+0x0): first defined here
/usr/bin/ld: ./src/float_vector.o:(.bss+0x2): multiple definition of `log_qdimacs_compliant'; ./src/aiger_utils.o:(.bss+0x2): first defined here
/usr/bin/ld: ./src/float_vector.o:(.bss+0x4): multiple definition of `debug_verbosity'; ./src/aiger_utils.o:(.bss+0x4): first defined here
/usr/bin/ld: ./src/heap.o:(.bss+0x4): multiple definition of `debug_verbosity'; ./src/aiger_utils.o:(.bss+0x4): first defined here
/usr/bin/ld: ./src/heap.o:(.bss+0x0): multiple definition of `log_silent'; ./src/aiger_utils.o:(.bss+0x0): first defined here
/usr/bin/ld: ./src/heap.o:(.bss+0x2): multiple definition of `log_qdimacs_compliant'; ./src/aiger_utils.o:(.bss+0x2): first defined here
/usr/bin/ld: ./src/heap.o:(.bss+0x1): multiple definition of `log_colors'; ./src/aiger_utils.o:(.bss+0x1): first defined here
/usr/bin/ld: ./src/int_vector.o:(.bss+0x1): multiple definition of `log_colors'; ./src/aiger_utils.o:(.bss+0x1): first defined here
/usr/bin/ld: ./src/int_vector.o:(.bss+0x0): multiple definition of `log_silent'; ./src/aiger_utils.o:(.bss+0x0): first defined here
/usr/bin/ld: ./src/int_vector.o:(.bss+0x2): multiple definition of `log_qdimacs_compliant'; ./src/aiger_utils.o:(.bss+0x2): first defined here
/usr/bin/ld: ./src/int_vector.o:(.bss+0x4): multiple definition of `debug_verbosity'; ./src/aiger_utils.o:(.bss+0x4): first defined here
/usr/bin/ld: ./src/log.o:(.bss+0x0): multiple definition of `log_silent'; ./src/aiger_utils.o:(.bss+0x0): first defined here
/usr/bin/ld: ./src/log.o:(.data+0x0): multiple definition of `log_colors'; ./src/aiger_utils.o:(.bss+0x1): first defined here
/usr/bin/ld: ./src/log.o:(.bss+0x1): multiple definition of `log_qdimacs_compliant'; ./src/aiger_utils.o:(.bss+0x2): first defined here
/usr/bin/ld: ./src/log.o:(.bss+0x4): multiple definition of `debug_verbosity'; ./src/aiger_utils.o:(.bss+0x4): first defined here
/usr/bin/ld: ./src/main.o:(.bss+0x0): multiple definition of `log_silent'; ./src/aiger_utils.o:(.bss+0x0): first defined here
/usr/bin/ld: ./src/main.o:(.bss+0x2): multiple definition of `log_qdimacs_compliant'; ./src/aiger_utils.o:(.bss+0x2): first defined here
/usr/bin/ld: ./src/main.o:(.bss+0x4): multiple definition of `debug_verbosity'; ./src/aiger_utils.o:(.bss+0x4): first defined here
/usr/bin/ld: ./src/main.o:(.bss+0x1): multiple definition of `log_colors'; ./src/aiger_utils.o:(.bss+0x1): first defined here
/usr/bin/ld: ./src/map.o:(.bss+0x0): multiple definition of `log_silent'; ./src/aiger_utils.o:(.bss+0x0): first defined here
/usr/bin/ld: ./src/map.o:(.bss+0x1): multiple definition of `log_colors'; ./src/aiger_utils.o:(.bss+0x1): first defined here
/usr/bin/ld: ./src/map.o:(.bss+0x2): multiple definition of `log_qdimacs_compliant'; ./src/aiger_utils.o:(.bss+0x2): first defined here
/usr/bin/ld: ./src/map.o:(.bss+0x4): multiple definition of `debug_verbosity'; ./src/aiger_utils.o:(.bss+0x4): first defined here
/usr/bin/ld: ./src/options.o:(.bss+0x4): multiple definition of `debug_verbosity'; ./src/aiger_utils.o:(.bss+0x4): first defined here
/usr/bin/ld: ./src/options.o:(.bss+0x0): multiple definition of `log_silent'; ./src/aiger_utils.o:(.bss+0x0): first defined here
/usr/bin/ld: ./src/options.o:(.bss+0x2): multiple definition of `log_qdimacs_compliant'; ./src/aiger_utils.o:(.bss+0x2): first defined here
/usr/bin/ld: ./src/options.o:(.bss+0x1): multiple definition of `log_colors'; ./src/aiger_utils.o:(.bss+0x1): first defined here
/usr/bin/ld: ./src/parse.o:(.bss+0x4): multiple definition of `debug_verbosity'; ./src/aiger_utils.o:(.bss+0x4): first defined here
/usr/bin/ld: ./src/parse.o:(.bss+0x0): multiple definition of `log_silent'; ./src/aiger_utils.o:(.bss+0x0): first defined here
/usr/bin/ld: ./src/parse.o:(.bss+0x2): multiple definition of `log_qdimacs_compliant'; ./src/aiger_utils.o:(.bss+0x2): first defined here
/usr/bin/ld: ./src/parse.o:(.bss+0x1): multiple definition of `log_colors'; ./src/aiger_utils.o:(.bss+0x1): first defined here
/usr/bin/ld: ./src/partial_assignment.o:(.bss+0x0): multiple definition of `log_silent'; ./src/aiger_utils.o:(.bss+0x0): first defined here
/usr/bin/ld: ./src/partial_assignment.o:(.bss+0x2): multiple definition of `log_qdimacs_compliant'; ./src/aiger_utils.o:(.bss+0x2): first defined here
/usr/bin/ld: ./src/partial_assignment.o:(.bss+0x1): multiple definition of `log_colors'; ./src/aiger_utils.o:(.bss+0x1): first defined here
/usr/bin/ld: ./src/partial_assignment.o:(.bss+0x4): multiple definition of `debug_verbosity'; ./src/aiger_utils.o:(.bss+0x4): first defined here
/usr/bin/ld: ./src/partitions.o:(.bss+0x1): multiple definition of `log_colors'; ./src/aiger_utils.o:(.bss+0x1): first defined here
/usr/bin/ld: ./src/partitions.o:(.bss+0x0): multiple definition of `log_silent'; ./src/aiger_utils.o:(.bss+0x0): first defined here
/usr/bin/ld: ./src/partitions.o:(.bss+0x2): multiple definition of `log_qdimacs_compliant'; ./src/aiger_utils.o:(.bss+0x2): first defined here
/usr/bin/ld: ./src/partitions.o:(.bss+0x4): multiple definition of `debug_verbosity'; ./src/aiger_utils.o:(.bss+0x4): first defined here
/usr/bin/ld: ./src/pqueue.o:(.bss+0x0): multiple definition of `log_silent'; ./src/aiger_utils.o:(.bss+0x0): first defined here
/usr/bin/ld: ./src/pqueue.o:(.bss+0x2): multiple definition of `log_qdimacs_compliant'; ./src/aiger_utils.o:(.bss+0x2): first defined here
/usr/bin/ld: ./src/pqueue.o:(.bss+0x1): multiple definition of `log_colors'; ./src/aiger_utils.o:(.bss+0x1): first defined here
/usr/bin/ld: ./src/pqueue.o:(.bss+0x4): multiple definition of `debug_verbosity'; ./src/aiger_utils.o:(.bss+0x4): first defined here
/usr/bin/ld: ./src/qcnf.o:(.bss+0x8): multiple definition of `log_silent'; ./src/aiger_utils.o:(.bss+0x0): first defined here
/usr/bin/ld: ./src/qcnf.o:(.bss+0xa): multiple definition of `log_qdimacs_compliant'; ./src/aiger_utils.o:(.bss+0x2): first defined here
/usr/bin/ld: ./src/qcnf.o:(.bss+0x9): multiple definition of `log_colors'; ./src/aiger_utils.o:(.bss+0x1): first defined here
/usr/bin/ld: ./src/qcnf.o:(.bss+0xc): multiple definition of `debug_verbosity'; ./src/aiger_utils.o:(.bss+0x4): first defined here
/usr/bin/ld: ./src/qipasir.o:(.bss+0x1): multiple definition of `log_colors'; ./src/aiger_utils.o:(.bss+0x1): first defined here
/usr/bin/ld: ./src/qipasir.o:(.bss+0x0): multiple definition of `log_silent'; ./src/aiger_utils.o:(.bss+0x0): first defined here
/usr/bin/ld: ./src/qipasir.o:(.bss+0x2): multiple definition of `log_qdimacs_compliant'; ./src/aiger_utils.o:(.bss+0x2): first defined here
/usr/bin/ld: ./src/qipasir.o:(.bss+0x4): multiple definition of `debug_verbosity'; ./src/aiger_utils.o:(.bss+0x4): first defined here
/usr/bin/ld: ./src/satsolver_picosat_assumptions.o:(.bss+0x1): multiple definition of `log_colors'; ./src/aiger_utils.o:(.bss+0x1): first defined here
/usr/bin/ld: ./src/satsolver_picosat_assumptions.o:(.bss+0x0): multiple definition of `log_silent'; ./src/aiger_utils.o:(.bss+0x0): first defined here
/usr/bin/ld: ./src/satsolver_picosat_assumptions.o:(.bss+0x2): multiple definition of `log_qdimacs_compliant'; ./src/aiger_utils.o:(.bss+0x2): first defined here
/usr/bin/ld: ./src/satsolver_picosat_assumptions.o:(.bss+0x4): multiple definition of `debug_verbosity'; ./src/aiger_utils.o:(.bss+0x4): first defined here
/usr/bin/ld: ./src/set.o:(.bss+0x4): multiple definition of `debug_verbosity'; ./src/aiger_utils.o:(.bss+0x4): first defined here
/usr/bin/ld: ./src/set.o:(.bss+0x0): multiple definition of `log_silent'; ./src/aiger_utils.o:(.bss+0x0): first defined here
/usr/bin/ld: ./src/set.o:(.bss+0x2): multiple definition of `log_qdimacs_compliant'; ./src/aiger_utils.o:(.bss+0x2): first defined here
/usr/bin/ld: ./src/set.o:(.bss+0x1): multiple definition of `log_colors'; ./src/aiger_utils.o:(.bss+0x1): first defined here
/usr/bin/ld: ./src/skolem.o:(.bss+0x0): multiple definition of `log_silent'; ./src/aiger_utils.o:(.bss+0x0): first defined here
/usr/bin/ld: ./src/skolem.o:(.bss+0x2): multiple definition of `log_qdimacs_compliant'; ./src/aiger_utils.o:(.bss+0x2): first defined here
/usr/bin/ld: ./src/skolem.o:(.bss+0x1): multiple definition of `log_colors'; ./src/aiger_utils.o:(.bss+0x1): first defined here
/usr/bin/ld: ./src/skolem.o:(.bss+0x4): multiple definition of `debug_verbosity'; ./src/aiger_utils.o:(.bss+0x4): first defined here
/usr/bin/ld: ./src/skolem_dependencies.o:(.bss+0x1): multiple definition of `log_colors'; ./src/aiger_utils.o:(.bss+0x1): first defined here
/usr/bin/ld: ./src/skolem_dependencies.o:(.bss+0x0): multiple definition of `log_silent'; ./src/aiger_utils.o:(.bss+0x0): first defined here
/usr/bin/ld: ./src/skolem_dependencies.o:(.bss+0x2): multiple definition of `log_qdimacs_compliant'; ./src/aiger_utils.o:(.bss+0x2): first defined here
/usr/bin/ld: ./src/skolem_dependencies.o:(.bss+0x4): multiple definition of `debug_verbosity'; ./src/aiger_utils.o:(.bss+0x4): first defined here
/usr/bin/ld: ./src/skolem_var.o:(.bss+0x4): multiple definition of `debug_verbosity'; ./src/aiger_utils.o:(.bss+0x4): first defined here
/usr/bin/ld: ./src/skolem_var.o:(.bss+0x0): multiple definition of `log_silent'; ./src/aiger_utils.o:(.bss+0x0): first defined here
/usr/bin/ld: ./src/skolem_var.o:(.bss+0x2): multiple definition of `log_qdimacs_compliant'; ./src/aiger_utils.o:(.bss+0x2): first defined here
/usr/bin/ld: ./src/skolem_var.o:(.bss+0x1): multiple definition of `log_colors'; ./src/aiger_utils.o:(.bss+0x1): first defined here
/usr/bin/ld: ./src/skolem_var_vector.o:(.bss+0x4): multiple definition of `debug_verbosity'; ./src/aiger_utils.o:(.bss+0x4): first defined here
/usr/bin/ld: ./src/skolem_var_vector.o:(.bss+0x0): multiple definition of `log_silent'; ./src/aiger_utils.o:(.bss+0x0): first defined here
/usr/bin/ld: ./src/skolem_var_vector.o:(.bss+0x2): multiple definition of `log_qdimacs_compliant'; ./src/aiger_utils.o:(.bss+0x2): first defined here
/usr/bin/ld: ./src/skolem_var_vector.o:(.bss+0x1): multiple definition of `log_colors'; ./src/aiger_utils.o:(.bss+0x1): first defined here
/usr/bin/ld: ./src/statistics.o:(.bss+0x0): multiple definition of `log_silent'; ./src/aiger_utils.o:(.bss+0x0): first defined here
/usr/bin/ld: ./src/statistics.o:(.bss+0x2): multiple definition of `log_qdimacs_compliant'; ./src/aiger_utils.o:(.bss+0x2): first defined here
/usr/bin/ld: ./src/statistics.o:(.bss+0x1): multiple definition of `log_colors'; ./src/aiger_utils.o:(.bss+0x1): first defined here
/usr/bin/ld: ./src/statistics.o:(.bss+0x4): multiple definition of `debug_verbosity'; ./src/aiger_utils.o:(.bss+0x4): first defined here
/usr/bin/ld: ./src/tests.o:(.bss+0x0): multiple definition of `log_silent'; ./src/aiger_utils.o:(.bss+0x0): first defined here
/usr/bin/ld: ./src/tests.o:(.bss+0x2): multiple definition of `log_qdimacs_compliant'; ./src/aiger_utils.o:(.bss+0x2): first defined here
/usr/bin/ld: ./src/tests.o:(.bss+0x1): multiple definition of `log_colors'; ./src/aiger_utils.o:(.bss+0x1): first defined here
/usr/bin/ld: ./src/tests.o:(.bss+0x4): multiple definition of `debug_verbosity'; ./src/aiger_utils.o:(.bss+0x4): first defined here
/usr/bin/ld: ./src/undo_stack.o:(.bss+0x4): multiple definition of `debug_verbosity'; ./src/aiger_utils.o:(.bss+0x4): first defined here
/usr/bin/ld: ./src/undo_stack.o:(.bss+0x0): multiple definition of `log_silent'; ./src/aiger_utils.o:(.bss+0x0): first defined here
/usr/bin/ld: ./src/undo_stack.o:(.bss+0x2): multiple definition of `log_qdimacs_compliant'; ./src/aiger_utils.o:(.bss+0x2): first defined here
/usr/bin/ld: ./src/undo_stack.o:(.bss+0x1): multiple definition of `log_colors'; ./src/aiger_utils.o:(.bss+0x1): first defined here
/usr/bin/ld: ./src/util.o:(.bss+0x4): multiple definition of `debug_verbosity'; ./src/aiger_utils.o:(.bss+0x4): first defined here
/usr/bin/ld: ./src/util.o:(.bss+0x0): multiple definition of `log_silent'; ./src/aiger_utils.o:(.bss+0x0): first defined here
/usr/bin/ld: ./src/util.o:(.bss+0x1): multiple definition of `log_colors'; ./src/aiger_utils.o:(.bss+0x1): first defined here
/usr/bin/ld: ./src/util.o:(.bss+0x2): multiple definition of `log_qdimacs_compliant'; ./src/aiger_utils.o:(.bss+0x2): first defined here
/usr/bin/ld: ./src/val_vector.o:(.bss+0x4): multiple definition of `debug_verbosity'; ./src/aiger_utils.o:(.bss+0x4): first defined here
/usr/bin/ld: ./src/val_vector.o:(.bss+0x0): multiple definition of `log_silent'; ./src/aiger_utils.o:(.bss+0x0): first defined here
/usr/bin/ld: ./src/val_vector.o:(.bss+0x2): multiple definition of `log_qdimacs_compliant'; ./src/aiger_utils.o:(.bss+0x2): first defined here
/usr/bin/ld: ./src/val_vector.o:(.bss+0x1): multiple definition of `log_colors'; ./src/aiger_utils.o:(.bss+0x1): first defined here
/usr/bin/ld: ./src/var_vector.o:(.bss+0x4): multiple definition of `debug_verbosity'; ./src/aiger_utils.o:(.bss+0x4): first defined here
/usr/bin/ld: ./src/var_vector.o:(.bss+0x0): multiple definition of `log_silent'; ./src/aiger_utils.o:(.bss+0x0): first defined here
/usr/bin/ld: ./src/var_vector.o:(.bss+0x2): multiple definition of `log_qdimacs_compliant'; ./src/aiger_utils.o:(.bss+0x2): first defined here
/usr/bin/ld: ./src/var_vector.o:(.bss+0x1): multiple definition of `log_colors'; ./src/aiger_utils.o:(.bss+0x1): first defined here
/usr/bin/ld: ./src/vector.o:(.bss+0x4): multiple definition of `debug_verbosity'; ./src/aiger_utils.o:(.bss+0x4): first defined here
/usr/bin/ld: ./src/vector.o:(.bss+0x0): multiple definition of `log_silent'; ./src/aiger_utils.o:(.bss+0x0): first defined here
/usr/bin/ld: ./src/vector.o:(.bss+0x2): multiple definition of `log_qdimacs_compliant'; ./src/aiger_utils.o:(.bss+0x2): first defined here
/usr/bin/ld: ./src/vector.o:(.bss+0x1): multiple definition of `log_colors'; ./src/aiger_utils.o:(.bss+0x1): first defined here
collect2: error: ld returned 1 exit status
make: *** [Makefile:31: cadet] Error 1
```